### PR TITLE
Make default max_retry_attempts configurable

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,9 @@ ATTRIBUTES
     The maximum number of retries we should attempt before giving up
     completely.
 
-    It defaults to 5.
+    It defaults to $Retry::MAX_RETRY_ATTEMPTS, whichis initially set to 5.
+    You may want to change this default to 0 to avoid retrying failures
+    during testing.
 
   failure_callback
     Optional. To be notified of *every* failure (even if we eventually

--- a/lib/Retry.pm
+++ b/lib/Retry.pm
@@ -5,6 +5,7 @@ use Moo;
 use MooX::Types::MooseLike::Base qw( Int CodeRef );
 
 our $VERSION = '1.03';
+our $MAX_RETRY_ATTEMPTS = 5;
 
 =head1 NAME
 
@@ -64,14 +65,14 @@ has 'retry_delay' => (
 
 The maximum number of retries we should attempt before giving up completely.
 
-It defaults to 5.
+It defaults to C<$Retry::MAX_RETRY_ATTEMPTS>, which is initially set to 5.
 
 =cut
 
 has 'max_retry_attempts' => (
     is => 'rw',
     isa => Int,
-    default => 5,
+    default => sub { $MAX_RETRY_ATTEMPTS },
 );
 
 =head2 failure_callback

--- a/t/retry.t
+++ b/t/retry.t
@@ -57,4 +57,15 @@ use Retry;
     is($result, 'win!', "Return value from sub was passed through.");
 }
 
+{
+    my $retry = Retry->new;
+    is(5, $retry->max_retry_attempts, "max_retry_attempts defaults to 5");
+}
+
+{
+    local $Retry::MAX_RETRY_ATTEMPTS = 2;
+    my $retry = Retry->new;
+    is(2, $retry->max_retry_attempts, "max_retry_attempts default can be changed");
+}
+
 done_testing();


### PR DESCRIPTION
Take the default for max_retry_attempts from a package variable.  This
allows the default to be changed, e.g. during test runs.

I added this to allow retries to be disabled when testing the "unhappy path". In a test, I can now do something like:

    local $Retry::MAX_RETRY_ATTEMPTS = 0;   # disable retries
    some_routine_that_uses_retry();   # failures will be raised immediately without retry

This change should be completely transparent to any existing code that uses Retry.

A limitation is that the change only allows disabling retries for code that does not set an explicit max_retry_attempts value.