### PR TITLE
Allow sleep method to be configured

### DIFF
--- a/README
+++ b/README
@@ -74,6 +74,18 @@ METHODS
            sub { unreliable_web_request() }
        );
 
+TESTING
+    When you are testing code that uses "Retry", you may want to disable the
+    actual sleep between retries. You can do this by setting the package
+    variable $Retry::SLEEP_METHOD to a code ref to replace the default
+    behavior of calling "CORE::sleep".
+
+    For example:
+
+        use Retry;
+        local $Retry::SLEEP_METHOD = sub { };   # don't sleep at all
+        some_code_that_uses_retry();            # retries will happen immediately
+
 AUTHOR
     Toby Corkindale -- https://github.com/TJC/
 

--- a/lib/Retry.pm
+++ b/lib/Retry.pm
@@ -6,6 +6,10 @@ use MooX::Types::MooseLike::Base qw( Int CodeRef );
 
 our $VERSION = '1.03';
 
+# code ref to sleep for passed number of seconds. called to delay between
+# retries.
+our $SLEEP_METHOD = \&CORE::sleep;
+
 =head1 NAME
 
 Retry
@@ -130,10 +134,23 @@ sub retry {
 
         die($error) unless $retries--;
 
-        sleep($delay);
+        $SLEEP_METHOD->($delay);
         $delay *= 2;
     }
 }
+
+=head1 TESTING
+
+When you are testing code that uses C<Retry>, you may want to disable the
+actual sleep between retries. You can do this by setting the package variable
+C<$Retry::SLEEP_METHOD> to a code ref to replace the default behavior of
+calling C<CORE::sleep>.
+
+For example:
+
+    use Retry;
+    local $Retry::SLEEP_METHOD = sub { };   # don't sleep at all
+    some_code_that_uses_retry();            # retries will happen immediately
 
 =head1 AUTHOR
 


### PR DESCRIPTION
This allows the sleep between retries to be disabled by setting a package variable `$Retry::SLEEP_METHOD`. This is a better technique than my previous pull request because it works with code that sets `max_retry_attempts`.

During testing, you can disable sleep between retries by setting, e.g.

    $Retry::SLEEP_METHOD = sub { };

Now tests that use `retry` will have retries performed immediately. I've done this in `t/retry.t` to speed up this module's own tests.

Again, this will be 100% transparent to existing code.

h/t https://rubygems.org/gems/retryable for this technique