### PR TITLE
fix lintian manpage-has-bad-whatis-entry error

### DIFF
--- a/lib/Retry.pm
+++ b/lib/Retry.pm
@@ -8,7 +8,7 @@ our $VERSION = '1.03';
 
 =head1 NAME
 
-Retry
+Retry - module to retry some logic with fallbacks
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Hello

While trying to package Retry for Debian, Lintian raised a _manpage-has-bad-whatis-entry_ error  due to NAME Pod section not having a description. Can you please include one ? 

Thank you

Regards